### PR TITLE
설치 실패 및 오류 수정 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 README.md
 arch.png
+^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: KoSpacing
 Type: Package
 Title: Automatic Korean word spacing with R
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Heewon", "Jeon", email = "madjakarta@gmail.com", role = c("aut", "cre")),
     person(given = "Chanyub",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,4 @@ Imports:
     hashmap,
     reticulate,
     rstudioapi
+Remotes: nathan-russell/hashmap

--- a/R/set_env.R
+++ b/R/set_env.R
@@ -1,7 +1,13 @@
 #' @importFrom reticulate import import_builtins py_module_available use_condaenv conda_create conda_install conda_list
 install_conda_packages <- function() {
   envnm <- 'r-kospacing'
+
   reticulate::use_condaenv(envnm, required = TRUE)
+
+  if (!reticulate::py_module_available("h5py")) {
+    reticulate::conda_install(envnm, packages = c('h5py==2.10.0'))
+  }
+
   if (!reticulate::py_module_available("tensorflow")) {
     reticulate::conda_install(envnm, packages = c('tensorflow==1.9.0'))
   }
@@ -10,20 +16,17 @@ install_conda_packages <- function() {
     reticulate::conda_install(envnm, packages = c('keras==2.1.5'))
   }
 
-  if (!reticulate::py_module_available("h5py")) {
-    reticulate::conda_install(envnm, packages = c('h5py==2.7.1'))
-  }
   cat("\nInstallation complete.\n\n")
 
   if (rstudioapi::hasFun("restartSession"))
-    rstudioapi::restartSession()
+    rstudioapi::restartSession("library(KoSpacing)")
   invisible(NULL)
 }
 
 check_env <- function() {
-  reticulate::py_module_available("h5py")&
-  reticulate::py_module_available("keras")&
-  reticulate::py_module_available("tensorflow")
+  reticulate::py_module_available("h5py") &
+    reticulate::py_module_available("keras") &
+    reticulate::py_module_available("tensorflow")
 }
 
 check_model <- function() {
@@ -38,7 +41,7 @@ check_model <- function() {
 
 #' @importFrom keras load_model_hdf5
 #' @importFrom hashmap load_hashmap
-set_model <- function(){
+set_model <- function() {
   w2idx <-
     file.path(system.file(package = "KoSpacing"), "model", 'w2idx')
 
@@ -49,7 +52,7 @@ set_model <- function(){
   model_file <-
     file.path(system.file(package = "KoSpacing"), "model", 'kospacing')
 
-  model <- keras::load_model_hdf5(model_file)
+  model <- keras::load_model_hdf5(model_file, compile = FALSE)
   packageStartupMessage("loaded KoSpacing model!")
   assign("model", model, envir = .KoSpacingEnv)
 }
@@ -57,7 +60,8 @@ set_model <- function(){
 
 check_conda_set <- function() {
   envnm <- 'r-kospacing'
-  chk <- try(reticulate::use_condaenv(envnm, required = TRUE), silent = T)
+  chk <-
+    try(reticulate::use_condaenv(envnm, required = TRUE), silent = T)
   if (class(chk) == "try-error") {
     res <- F
   } else {
@@ -70,7 +74,10 @@ check_conda_set <- function() {
 #'
 #' @importFrom reticulate conda_create
 #' @export
-set_env <- function(){
-  reticulate::conda_create("r-kospacing", packages = "python=3.6")
+set_env <- function() {
+  reticulate::conda_create("r-kospacing",
+                           # python_version = "3.6",
+                           packages = c("python=3.6","numpy=1.16.5"),
+                          )
   install_conda_packages()
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,92 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# KoSpacing
+
+<!-- badges: start -->
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
+<!-- badges: end -->
+
+R package for automatic Korean word spacing.  
+
+Python verson can be found [here](https://github.com/haven-jeon/PyKoSpacing).
+
+#### Introduction
+
+Word spacing is one of the important parts of the preprocessing of Korean text analysis. Accurate spacing greatly affects the accuracy of subsequent text analysis. `KoSpacing` has fairly accurate automatic word spacing performance, especially good for online text originated from SNS or SMS.
+
+
+For example.
+
+"아버지가방에들어가신다." can be spaced both of below.
+
+
+1. "아버지가 방에 들어가신다." means  "My father enters the room."
+1. "아버지 가방에 들어가신다." means  "My father goes into the bag."
+
+Common sense, the first is the right answer.
+
+
+`KoSpacing` is based on Deep Learning model trained from large corpus(more than 100 million NEWS articles from [Chan-Yub Park](https://github.com/mrchypark)). 
+
+
+#### Performance
+
+| Test Set  | Accuracy | 
+|---|---|
+| Sejong(colloquial style) Corpus(1M) | 97.1% |
+| OOOO(literary style)  Corpus(3M)   | 94.3% |
+
+- Accuracy = # correctly spaced characters/# characters in the test data.
+  - Might be increased performance if normalize compound words. 
+
+
+#### Install
+
+To install from GitHub, use
+
+```
+install.packages('remotes')
+remotes::install_github('haven-jeon/KoSpacing')
+library(KoSpacing)
+set_env()
+```
+
+#### Example 
+
+```{r}
+library(KoSpacing)
+spacing("김형호영화시장분석가는'1987'의네이버영화정보네티즌10점평에서언급된단어들을지난해12월27일부터올해1월10일까지통계프로그램R과KoNLP패키지로텍스트마이닝하여분석했다.")
+```
+
+#### Model Architecture
+
+![](arch.png)
+
+
+#### Citation
+
+
+```markdowns
+@misc{heewon2018,
+author = {Heewon Jeon},
+title = {KoSpacing: Automatic Korean word spacing},
+publisher = {GitHub},
+journal = {GitHub repository},
+howpublished = {\url{https://github.com/haven-jeon/KoSpacing}}
+```
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,71 +1,78 @@
-KoSpacing 
----------------
 
-R package for automatic Korean word spacing.  
+<!-- README.md is generated from README.Rmd. Please edit that file -->
 
-Python verson can be found [here](https://github.com/haven-jeon/PyKoSpacing).
+# KoSpacing
 
+<!-- badges: start -->
 
+[![License: GPL
+v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
+<!-- badges: end -->
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
+R package for automatic Korean word spacing.
 
+Python verson can be found
+[here](https://github.com/haven-jeon/PyKoSpacing).
 
 #### Introduction
 
-Word spacing is one of the important parts of the preprocessing of Korean text analysis. Accurate spacing greatly affects the accuracy of subsequent text analysis. `KoSpacing` has fairly accurate automatic word spacing performance, especially good for online text originated from SNS or SMS.
-
+Word spacing is one of the important parts of the preprocessing of
+Korean text analysis. Accurate spacing greatly affects the accuracy of
+subsequent text analysis. `KoSpacing` has fairly accurate automatic word
+spacing performance, especially good for online text originated from SNS
+or SMS.
 
 For example.
 
-"아버지가방에들어가신다." can be spaced both of below.
+“아버지가방에들어가신다.” can be spaced both of below.
 
-
-1. "아버지가 방에 들어가신다." means  "My father enters the room."
-1. "아버지 가방에 들어가신다." means  "My father goes into the bag."
+1.  “아버지가 방에 들어가신다.” means “My father enters the room.”
+2.  “아버지 가방에 들어가신다.” means “My father goes into the bag.”
 
 Common sense, the first is the right answer.
 
-
-`KoSpacing` is based on Deep Learning model trained from large corpus(more than 100 million NEWS articles from [Chan-Yub Park](https://github.com/mrchypark)). 
-
+`KoSpacing` is based on Deep Learning model trained from large
+corpus(more than 100 million NEWS articles from [Chan-Yub
+Park](https://github.com/mrchypark)).
 
 #### Performance
 
-| Test Set  | Accuracy | 
-|---|---|
-| Sejong(colloquial style) Corpus(1M) | 97.1% |
-| OOOO(literary style)  Corpus(3M)   | 94.3% |
+| Test Set                            | Accuracy |
+|-------------------------------------|----------|
+| Sejong(colloquial style) Corpus(1M) | 97.1%    |
+| OOOO(literary style) Corpus(3M)     | 94.3%    |
 
-- Accuracy = # correctly spaced characters/# characters in the test data.
-  - Might be increased performance if normalize compound words. 
-
+-   Accuracy = \# correctly spaced characters/\# characters in the test
+    data.
+    -   Might be increased performance if normalize compound words.
 
 #### Install
 
-You need to install conda binary from https://www.anaconda.com/download/. Please install Python 3.6 version or later.
-
 To install from GitHub, use
 
-    install.packages('devtools')
-    devtools::install_github('haven-jeon/KoSpacing')
-
-
-#### Example 
-
+    install.packages('remotes')
+    remotes::install_github('haven-jeon/KoSpacing')
     library(KoSpacing)
-    spacing("김형호영화시장분석가는'1987'의네이버영화정보네티즌10점평에서언급된단어들을지난해12월27일부터올해1월10일까지통계프로그램R과KoNLP패키지로텍스트마이닝하여분석했다.")
-    [1] "김형호 영화시장 분석가는 '1987'의 네이버 영화 정보 네티즌 10점 평에서 언급된 단어들을 지난해 12월 27일부터 올해 1월 10일까지 통계 프로그램 R과 KoNLP 패키지로 텍스트마이닝하여 분석했다."
+    set_env()
 
+#### Example
+
+``` r
+library(KoSpacing)
+#> If you install package first fime,
+#> Please set_env() run before using spacing()
+spacing("김형호영화시장분석가는'1987'의네이버영화정보네티즌10점평에서언급된단어들을지난해12월27일부터올해1월10일까지통계프로그램R과KoNLP패키지로텍스트마이닝하여분석했다.")
+#> loaded KoSpacing model!
+#> [1] "김형호 영화시장 분석가는 '1987'의 네이버 영화 정보 네티즌 10점 평에서 언급된 단어들을 지난해 12월 27일부터 올해 1월 10일까지 통계 프로그램 R과 KoNLP 패키지로 텍스트마이닝하여 분석했다."
+```
 
 #### Model Architecture
 
 ![](arch.png)
 
-
 #### Citation
 
-
-```markdowns
+``` markdowns
 @misc{heewon2018,
 author = {Heewon Jeon},
 title = {KoSpacing: Automatic Korean word spacing},
@@ -73,6 +80,3 @@ publisher = {GitHub},
 journal = {GitHub repository},
 howpublished = {\url{https://github.com/haven-jeon/KoSpacing}}
 ```
-
-
-


### PR DESCRIPTION
아래 오류를 확인한 결과, keras 2.1.5 버전에서는 h5py에서 3.0.0 버전에서 호환되지 않는 문제가 있다는 사실을 확인했습니다.(https://github.com/tensorflow/tensorflow/issues/44467)
기존에도 h5py를 버전 지정하여 설치하도록 하였으나, 순서 문제로 최신 버전이 설치되어 아래와 같은 문제가 있었습니다.

그래서 패키지 설치 순서를 변경하여 문제를 해결하였습니다.

```
Error in py_call_impl(callable, dots$args, dots$keywords) :
AttributeError: 'str' object has no attribute 'decode'

Detailed traceback:
File "C:\PROGRA~3\MINICO~1\envs\R-KOSP~1\lib\site-packages\tensorflow\python\keras\engine\saving.py", line 228, in load_model
model_config = json.loads(model_config.decode('utf-8'))
```

그리고 hashmap이 cran에서 내려가서 설치 동작시 문제가 있습니다.
description에 hashmap의 github 주소를 추가하여 설치 동작시 github에서 설치하도록 작성하였습니다.

이번 버그 수정으로 version을 0.1.2로 올렸습니다.

readme에 set_env() 함수를 소개하는 내용을 추가하면서 rmd 기반 readme로 변경하였습니다.